### PR TITLE
register code block processors after setting modification

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -325,6 +325,12 @@ class AsciiMathSettingTab extends PluginSettingTab {
           }
           await this.plugin.saveSettings()
           await this.plugin.loadSettings()
+          this.plugin.settings.blockPrefix.forEach((prefix) => {
+            // console.log(prefix)
+            try {
+              this.plugin.registerAsciiMathBlock(prefix);
+            } catch (error) {}
+          });    
           new Notice('Asciimath settings reloaded successfully!')
         }))
   }


### PR DESCRIPTION
If you modify the prefixes list, in settings, the document is updated without having to restart obsidian.
the try is to avoid error if the code block processor already existed for a prefix.