### PR TITLE
Math block replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ I've recently refactored the library, and you can refer to [asciimath-parser](ht
 
 **Warning**: Some of the rules are not exactly consistent with http://asciimath.org, especially the matrix. For more information, please refer to https://asciimath.widcard.win.
 
+
+#### Migrating from notes created with plugin version version 0.6.3 or lower.
+
+In previous version of the plugin users had to use this special syntax for inline math. This feature is deprecated is will be removed in the future.
+> Note: default code blocks with three backticks will be supported as usual.
+
+To prepare your notes for the newer version of the plugin, you must convert your old AsciiMath notes to LaTeX. You can do this by using commands:
+- Hit `Ctrl + P` to open up command pallet.
+- Search for "Convert AsciiMath to LaTeX". Choose one of the two available commands by the "obsidian-asciimath" plugin.
+- Confirm the changes.
+- You're good to go!
+
 #### Code block
 
 ~~~text
@@ -43,53 +55,17 @@ x & |-> "e"^(2pi "i" x)
 > \end{aligned}
 > ```
 
-#### Inline asciimath
+#### Using dollar-sign math blocks.
+Default obsidian math is wrapped in `$` on both ends for the inline math with `$$` for the display-style block.  
+You can enable "Replace math block" in the plugin settings which allows the plugin to render AsciiMath inside of dollar-sign blocks.
+> The neat part is that you can keep your LaTeX math blocks as they are, because the plugin is smart enough to guess which syntax is used for a particular block.
 
-By default, the inline formula should be wrapped with \`\$ and \$\`, that is, you should input the formula like
-
-```markdown
-The integral `$int _0^(+oo) "e"^(-x) dx = 1$`.
-```
-
-![](screenshots/inline.png)
-
-## Configuration
-
-You can add other prefix alias of code block in the settings. The default values are `asciimath` and `am`.
-
-Inline formula **can only** be wrapped with special escapes. Just look at the examples below.
-
-```diff
-- start: ``   !!! invalid !!!
-- end:   ``   !!! invalid !!!
-
-- start: `    !!! invalid !!!
-- end:   `    !!! invalid !!!
-
-+ start: `$   √√√  valid  √√√  // default
-+ end:   $`   √√√  valid  √√√  // default
-
-+ start: `$$  √√√  valid  √√√
-+ end:   $$`  √√√  valid  √√√
-
-+ start: `*   √√√  valid  √√√
-+ end:   *`   √√√  valid  √√√
-
-+ start: `{   √√√  valid  √√√
-+ end:   }`   √√√  valid  √√√
-
-+ start: `[   √√√  valid  √√√
-+ end:   ]`   √√√  valid  √√√
-
-(... any other valid escapes ...)
-```
-
-After changing the settings, **DON'T FORGET to hit the "Save" button**.
 
 ## Commands
 
 - Insert asciimath codeblock
 - Convert asciimath into mathjax in current file
+- Convert asciimath into mathjax in the entire vault.
 
 ![](screenshots/out.gif)
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ I've recently refactored the library, and you can refer to [asciimath-parser](ht
 **Warning**: Some of the rules are not exactly consistent with http://asciimath.org, especially the matrix. For more information, please refer to https://asciimath.widcard.win.
 
 
-#### Migrating from notes created with plugin version version 0.6.3 or lower.
+### Migrating from notes created with plugin version 0.6.3 or lower.
 
-In previous version of the plugin users had to use this special syntax for inline math. This feature is deprecated is will be removed in the future.
+In previous versions of the plugin users had to use this special syntax for inline math. This feature is deprecated and will be removed in the future.
 > Note: default code blocks with three backticks will be supported as usual.
 
 To prepare your notes for the newer version of the plugin, you must convert your old AsciiMath notes to LaTeX. You can do this by using commands:
@@ -56,8 +56,8 @@ x & |-> "e"^(2pi "i" x)
 > ```
 
 #### Using dollar-sign math blocks.
-Default obsidian math is wrapped in `$` on both ends for the inline math with `$$` for the display-style block.  
-You can enable "Replace math block" in the plugin settings which allows the plugin to render AsciiMath inside of dollar-sign blocks.
+Default obsidian math is wrapped in `$` on both ends for the inline math and with `$$` for the display-style block.  
+You can enable "Replace math block" option in the plugin settings which allows the plugin to render AsciiMath inside of dollar-sign blocks.
 > The neat part is that you can keep your LaTeX math blocks as they are, because the plugin is smart enough to guess which syntax is used for a particular block.
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,19 @@ export default class AsciiMathPlugin extends Plugin {
       })
     })
 
+    // Deprecation warning for the inline math syntax
+    this.app.workspace.on('file-open', async (file) => {
+      if (!file)
+        return
+
+      const content = await this.app.vault.read(file)
+
+      const [open, close] = Object.values(this.settings.inline).map(normalizeEscape)
+      const inlineReg = new RegExp(`${open}(.*?)${close}`, 'g')
+      if (inlineReg.test(content))
+        new Notice('Inline math with single backticks is deprecated. Refer to the plugin description to fix this issue', 20)
+    })
+
     // register processor in live preview mode
     this.registerEditorExtension([inlinePlugin(this)])
 

--- a/src/mathjax.d.ts
+++ b/src/mathjax.d.ts
@@ -1,0 +1,4 @@
+interface IMathJax {
+   tex2chtml: (source: string, r: { display: boolean }) => any 
+}
+declare const MathJax: IMathJax

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,14 @@ function normalizeEscape(escape: string) {
   return escape.replace(/([$^\\.()[\]{}*?|])/g, '\\$1')
 }
 
+const latexRegex = /\\([A-Za-z0-9]){2,}/gm
+const texEmbedRegex = /tex".*"/
+// This function checks if the given code contains LaTeX code, but it's not AsciiMath embed.
+function isLatexCode(code: string): boolean {
+  return latexRegex.test(code) && !texEmbedRegex.test(code)
+}
+
 export {
   normalizeEscape,
+  isLatexCode,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,10 +2,11 @@ function normalizeEscape(escape: string) {
   return escape.replace(/([$^\\.()[\]{}*?|])/g, '\\$1')
 }
 
-const latexRegex = /\\([A-Za-z0-9]){2,}/gm
-const texEmbedRegex = /tex".*"/
 // This function checks if the given code contains LaTeX code, but it's not AsciiMath embed.
 function isLatexCode(code: string): boolean {
+  const latexRegex = /\\([A-Za-z0-9]){2,}/gm
+  const texEmbedRegex = /tex".*"/
+
   return latexRegex.test(code) && !texEmbedRegex.test(code)
 }
 


### PR DESCRIPTION
This PR implements functionality needed for the first release mentioned in #9, which is deprecating old inline blocks and using default obsidian math dollar-sign blocks instead.

Added functonality:
- Commands for replacing AsciiMath blocks with LaTeX code (current file or vault)
- Additing options and functinality for processing default math dollar-sign blocks by converting AsciiMath to tex if found (or leaving tex as is otherwise) and passing it to default obsidian math rendering.